### PR TITLE
Fix whitespace on namespaces

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -70,7 +70,7 @@ class GenerateCommand extends Command
             return str_replace(
                     ['namespace ', ';'],
                     [''],
-                    $matches[0]
+                    trim($matches[0])
                 ) . "\\{$file->getBasename('.php')}";
         });
     }


### PR DESCRIPTION
before (notice the added `\r` after `App\Models`):
```
Illuminate\Support\Collection^ {#913
  #items: array:6 [
    0 => "App\Models\Category"
    1 => "App\Models\r\Currency"
    2 => "App\Models\r\Organization"
    3 => "App\Models\Price"
    4 => "App\Models\Product"
    5 => "App\Models\r\User"
  ]
}
```
after:
```
Illuminate\Support\Collection^ {#913
  #items: array:6 [
    0 => "App\Models\Category"
    1 => "App\Models\Currency"
    2 => "App\Models\Organization"
    3 => "App\Models\Price"
    4 => "App\Models\Product"
    5 => "App\Models\User"
  ]
}
```