### PR TITLE
resolves #7

### DIFF
--- a/src/TypeGuesser.php
+++ b/src/TypeGuesser.php
@@ -39,14 +39,20 @@ class TypeGuesser
      */
     public function guess($name, Type $type, $size = null)
     {
-        $name = str_replace('_', '', Str::lower($name));
+        $name = Str::of($name)->lower();
 
-        if (!$size && $this->hasNativeResolverFor($name)) {
-            return $name;
+        if ($name->endsWith('_id')) {
+            return 'integer';
         }
+
+        $name = $name->replace('_', '')->__toString();
 
         if (self::$default !== $typeNameGuess = $this->guessBasedOnName($name, $size)) {
             return $typeNameGuess;
+        }
+
+        if ($this->hasNativeResolverFor($name)) {
+            return $name;
         }
 
         return $this->guessBasedOnType($type, $size);


### PR DESCRIPTION
**changed**
- columns ending with `_id` which are not foreign keys and are not used in relationship methods on the model are now mapped to `integer`
- `guessBasedOnName()` method call happens before call of `hasNativeResolverFor()` in order to get a better control of what to return per column name
- removed the `!$size` check on the condition for the `hasNativeResolverFor()` call, since this prevented the method from being called and it wasn't necessary in the first place ;)