### PR TITLE
update faker to maintained version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["laravel", "factory", "model", "testing"],
     "require": {
         "illuminate/support": "^8.0",
-        "fzaninotto/faker": "^1.9.1",
+        "fakerphp/faker": "^1.9.1",
         "naoray/eloquent-model-analyzer": "^2.0",
         "nikic/php-parser": "^4.0"
     },


### PR DESCRIPTION
Just got the following error when trying to require this package:
![image](https://user-images.githubusercontent.com/10154100/101830401-bd961580-3b34-11eb-8fed-65dcab359805.png)

It occurred because `laravel/laravel` repo changed their dependency to the new `fakerphp/faker` package because the original faker package has been archived (s. https://laravel-news.com/changes-coming-to-php-faker)