### PR TITLE
Make sure the actual namespace is captured

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -67,7 +67,7 @@ class GenerateCommand extends Command
         }
 
         return collect(File::allFiles($directory))->map(function (SplFileInfo $file) {
-            if (!preg_match('/namespace\s.*/', $file->getContents(), $matches)) {
+            if (!preg_match('/^namespace\s.*/m', $file->getContents(), $matches)) {
                 return null;
             }
 

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -67,15 +67,11 @@ class GenerateCommand extends Command
         }
 
         return collect(File::allFiles($directory))->map(function (SplFileInfo $file) {
-            if (!preg_match('/^namespace\s.*/m', $file->getContents(), $matches)) {
+            if (!preg_match('/^namespace\s(\S+)/m', $file->getContents(), $matches)) {
                 return null;
             }
 
-            return str_replace(
-                    ['namespace ', ';'],
-                    [''],
-                    trim($matches[0])
-                ) . "\\{$file->getBasename('.php')}";
+            return $matches[1] . '\\' . $file->getBasename('.php');
         })->filter();
     }
 


### PR DESCRIPTION
I had a class like this:
```php
<?php
/** @todo move to separate namespace */
namespace App;

class SomeClass
{
   //...
}
```
Which made `loadModels()` interpret the FQN as `*/\SomeClass` because it just captures whatever comes after the first occurence of `namespace`.

This change ignores occurences of `namespace` that are not at the beginning of the line.