### PR TITLE
Don't capture semicolon in namespace regex

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -67,7 +67,7 @@ class GenerateCommand extends Command
         }
 
         return collect(File::allFiles($directory))->map(function (SplFileInfo $file) {
-            if (!preg_match('/^namespace\s(\S+)/m', $file->getContents(), $matches)) {
+            if (!preg_match('/^namespace\s([^\s;]+)/m', $file->getContents(), $matches)) {
                 return null;
             }
 

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -67,7 +67,7 @@ class GenerateCommand extends Command
         }
 
         return collect(File::allFiles($directory))->map(function (SplFileInfo $file) {
-            if (!preg_match('/^namespace\s([^\s;]+)/m', $file->getContents(), $matches)) {
+            if (!preg_match('/^namespace\s+([^;]+)/m', $file->getContents(), $matches)) {
                 return null;
             }
 


### PR DESCRIPTION
The capture group introduced in https://github.com/laravel-shift/factory-generator/pull/16/commits/1089b7074c11261373e19aca2d5699c02ecc4155 also captures the trailing semicolon. This should fix that.