### PR TITLE
Use factory namespace expected by Laravel.

### DIFF
--- a/src/FactoryGenerator.php
+++ b/src/FactoryGenerator.php
@@ -267,9 +267,7 @@ class FactoryGenerator
         }
 
         $factoryQualifiedName = \Illuminate\Database\Eloquent\Factories\Factory::resolveFactoryName($modelClass);
-        $factoryNamespace = (string) Str::of($factoryQualifiedName)
-            ->replaceLast(class_basename($factoryQualifiedName), '')
-            ->rtrim('\\');
+        $factoryNamespace = Str::beforeLast($factoryQualifiedName, '\\');
         $contents = File::get(__DIR__ . '/../stubs/factory.stub');
         $contents = str_replace('{{ factoryNamespace }}', $factoryNamespace, $contents);
         $contents = str_replace('{{ namespacedModel }}', $modelClass, $contents);

--- a/src/FactoryGenerator.php
+++ b/src/FactoryGenerator.php
@@ -266,8 +266,12 @@ class FactoryGenerator
             $definition .= PHP_EOL . '            ' . $value . ',';
         }
 
+        $factoryQualifiedName = \Illuminate\Database\Eloquent\Factories\Factory::resolveFactoryName($modelClass);
+        $factoryNamespace = (string) Str::of($factoryQualifiedName)
+            ->replaceLast(class_basename($factoryQualifiedName), '')
+            ->rtrim('\\');
         $contents = File::get(__DIR__ . '/../stubs/factory.stub');
-        $contents = str_replace('{{ factoryNamespace }}', 'Database\\Factories', $contents);
+        $contents = str_replace('{{ factoryNamespace }}', $factoryNamespace, $contents);
         $contents = str_replace('{{ namespacedModel }}', $modelClass, $contents);
         $contents = str_replace('{{ model }}', class_basename($modelClass), $contents);
         $contents = str_replace('            //', trim($definition, PHP_EOL), $contents);


### PR DESCRIPTION
This fixes #18 by assigning the namespace Laravel expects when calling `Model::factory()`.

I'm a bit confused about #1 because it only mentions that factory classes should be put in nested folders, which they already are.

By the way, I tried to run the tests. Can you confirm that they need to be updated before they will work, or is it just in my environment?