### PR TITLE
Support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["laravel", "factory", "model", "testing"],
     "require": {
-        "illuminate/support": "^8.0",
+        "illuminate/support": "^8.0|^9.0",
         "fakerphp/faker": "^1.9.1",
         "naoray/eloquent-model-analyzer": "^2.0",
         "nikic/php-parser": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "illuminate/support": "^8.0|^9.0",
         "fakerphp/faker": "^1.9.1",
-        "naoray/eloquent-model-analyzer": "^2.0",
+        "naoray/eloquent-model-analyzer": "^2.0|^3.0",
         "nikic/php-parser": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
New version support for `illuminate/support` and `naoray/eloquent-model-analyzer` to work with Laravel 9, the question is whether the existing value should be modified or as I've done it now. The package works on my own dev environment.