### PR TITLE
Get proper cased method names

### DIFF
--- a/src/TypeGuesser.php
+++ b/src/TypeGuesser.php
@@ -72,21 +72,13 @@ class TypeGuesser
     {
         switch ($name) {
             case 'login':
-            case 'username':
                 return 'userName()';
-            case 'firstname':
-                return 'firstName()';
-            case 'lastname':
-                return 'lastName()';
-            case 'streetaddress':
-                return 'streetAddress()';
             case 'email_address':
             case 'emailaddress':
                 return 'email()';
             case 'phone':
             case 'telephone':
             case 'telnumber':
-            case 'phonenumber':
                 return 'phoneNumber()';
             case 'town':
                 return 'city()';
@@ -101,7 +93,6 @@ class TypeGuesser
             case 'country':
                 return $this->predictCountryType($size);
             case 'currency':
-            case 'currencycode':
                 return 'currencyCode()';
             case 'website':
                 return 'url()';

--- a/src/TypeGuesser.php
+++ b/src/TypeGuesser.php
@@ -119,7 +119,7 @@ class TypeGuesser
         if (empty($this->fakerMethodNames)) {
             $this->fakerMethodNames = collect($this->generator->getProviders())
                 ->flatMap(function(Base $provider) {
-                    return$this->getNamesFromProvidor($provider);
+                    return $this->getNamesFromProvidor($provider);
                 })
                 ->unique()
                 ->toArray();

--- a/src/TypeGuesser.php
+++ b/src/TypeGuesser.php
@@ -16,11 +16,6 @@ class TypeGuesser
     protected $generator;
 
     /**
-     * @var array
-     */
-    protected $fakerMethodNames = [];
-
-    /**
      * Create a new TypeGuesser instance.
      *
      * @param \Faker\Generator $generator
@@ -116,8 +111,10 @@ class TypeGuesser
      */
     protected function nativeNameFor(string $lookup)
     {
-        if (empty($this->fakerMethodNames)) {
-            $this->fakerMethodNames = collect($this->generator->getProviders())
+        static $fakerMethodNames = [];
+
+        if (empty($fakerMethodNames)) {
+            $fakerMethodNames = collect($this->generator->getProviders())
                 ->flatMap(function(Base $provider) {
                     return $this->getNamesFromProvider($provider);
                 })
@@ -125,8 +122,8 @@ class TypeGuesser
                 ->toArray();
         }
 
-        if (isset($this->fakerMethodNames[$lookup])) {
-            return $this->fakerMethodNames[$lookup];
+        if (isset($fakerMethodNames[$lookup])) {
+            return $fakerMethodNames[$lookup];
         }
 
         return null;

--- a/src/TypeGuesser.php
+++ b/src/TypeGuesser.php
@@ -119,7 +119,7 @@ class TypeGuesser
         if (empty($this->fakerMethodNames)) {
             $this->fakerMethodNames = collect($this->generator->getProviders())
                 ->flatMap(function(Base $provider) {
-                    return $this->getNamesFromProvidor($provider);
+                    return $this->getNamesFromProvider($provider);
                 })
                 ->unique()
                 ->toArray();
@@ -139,7 +139,7 @@ class TypeGuesser
      *
      * @return array
      */
-    protected function getNamesFromProvidor(Base $provider)
+    protected function getNamesFromProvider(Base $provider)
     {
         return collect(get_class_methods($provider))
             ->reject(function(string $methodName) {


### PR DESCRIPTION
`get_class_methods` will return only public accessible method
Visibility example from the [docs](https://www.php.net/manual/en/function.get-class-methods.php#95548)
[Usage](https://php-safari.com/function/get_class_methods) in laravel ecosystem 
