### PR TITLE
Bumped eloquent-model-analyzer to 4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "illuminate/support": "^10.0",
         "fakerphp/faker": "^1.9.1",
-        "naoray/eloquent-model-analyzer": "^3.0.1",
+        "naoray/eloquent-model-analyzer": "^4.0.0",
         "nikic/php-parser": "^4.15"
     },
     "require-dev": {


### PR DESCRIPTION
@Naoray bumped the version to 4.0.0 to introduce Laravel 10 support after merging your PR.