### PR TITLE
Ignoring abstract model classes

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -33,7 +33,9 @@ class GenerateCommand extends Command
 
         $this->loadModels($directory, $models)
             ->filter(function ($model) {
-                return (new ReflectionClass($model))->isSubclassOf(Model::class) && ! (new ReflectionClass($model))->isAbstract();
+                $model = new ReflectionClass($model);
+                
+                return $model->isSubclassOf(Model::class) && ! $model->isAbstract();
             })
             ->each(function ($model) use ($generator) {
                 $factory = $generator->generate($model);

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -33,7 +33,8 @@ class GenerateCommand extends Command
 
         $this->loadModels($directory, $models)
             ->filter(function ($model) {
-                return (new ReflectionClass($model))->isSubclassOf(Model::class);
+                return (new ReflectionClass($model))->isSubclassOf(Model::class) && ! (new ReflectionClass($model))->isAbstract();
+
             })
             ->each(function ($model) use ($generator) {
                 $factory = $generator->generate($model);

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -34,7 +34,6 @@ class GenerateCommand extends Command
         $this->loadModels($directory, $models)
             ->filter(function ($model) {
                 return (new ReflectionClass($model))->isSubclassOf(Model::class) && ! (new ReflectionClass($model))->isAbstract();
-
             })
             ->each(function ($model) use ($generator) {
                 $factory = $generator->generate($model);


### PR DESCRIPTION
I had an issue where one of my models is abstract. I use this class for inheritance on other models so it does not have a table.

Anyway, this caused a failure to generate all factories so I put in a quick fix for it.