### PR TITLE
Updated the predictCountryType function to accept null for the $size value

### DIFF
--- a/src/TypeGuesser.php
+++ b/src/TypeGuesser.php
@@ -181,7 +181,7 @@ class TypeGuesser
     /**
      * Predicts country code based on $size.
      */
-    protected function predictCountryType(int $size): string
+    protected function predictCountryType(?int $size): string
     {
         return match ($size) {
             2 => 'countryCode()',


### PR DESCRIPTION
Null is a valid value for the size variable and the one function it is called from (guessBasedOnName) has a default value for its input $size variable of null.